### PR TITLE
Fix warning for gst version

### DIFF
--- a/rgain/rgcalc.py
+++ b/rgain/rgcalc.py
@@ -19,11 +19,12 @@ documentation or use the ``calculate`` function.
 """
 
 import gi
-from gi.repository import GObject, Gst  # noqa
-
-from rgain import GainData, GainType, GSTError, util  # noqa
 
 gi.require_version('Gst', '1.0')
+
+from gi.repository import GObject, Gst  # noqa isort:skip
+
+from rgain import GainData, GainType, GSTError, util  # noqa isort:skip
 
 
 class MissingPluginsError(Exception):

--- a/rgain/script/__init__.py
+++ b/rgain/script/__init__.py
@@ -21,12 +21,13 @@ import traceback
 from optparse import OptionParser
 
 import gi
-from gi.repository import Gst  # noqa
-
-import rgain.rgio  # noqa
-from rgain import __version__  # noqa
 
 gi.require_version("Gst", "1.0")
+
+from gi.repository import Gst  # noqa isort:skip
+
+import rgain.rgio  # noqa  isort:skip
+from rgain import __version__  # noqa isort:skip
 
 
 __all__ = [

--- a/scripts/collectiongain
+++ b/scripts/collectiongain
@@ -5,4 +5,3 @@ from rgain.script.collectiongain import collectiongain
 
 if __name__ == "__main__":
     collectiongain()
-

--- a/scripts/replaygain
+++ b/scripts/replaygain
@@ -5,4 +5,3 @@ from rgain.script.replaygain import replaygain
 
 if __name__ == "__main__":
     replaygain()
-

--- a/test/test_rgcalc.py
+++ b/test/test_rgcalc.py
@@ -1,13 +1,14 @@
 import os.path
 import unittest
 
-# Have to set up GStreamer for all these tests.
 import gi
-from gi.repository import GObject, Gst  # noqa
-
-from rgain import GainType, rgcalc, util
 
 gi.require_version("Gst", "1.0")
+
+from gi.repository import GObject, Gst  # noqa isort:skip
+
+from rgain import GainType, rgcalc, util  # noqa isort:skip
+
 Gst.init([])
 
 


### PR DESCRIPTION
This commit removes the Gst warning

```
/usr/lib/python3/dist-packages/rgain/script/__init__.py:24: PyGIWarning: Gst was imported without specifying a version first. Use gi.require_version('Gst', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gst  # noqa
```