### PR TITLE
Fix deprecation warnings

### DIFF
--- a/rgain3/rgcalc.py
+++ b/rgain3/rgcalc.py
@@ -22,7 +22,7 @@ import gi
 
 gi.require_version('Gst', '1.0')
 
-from gi.repository import GObject, Gst  # noqa isort:skip
+from gi.repository import GLib, GObject, Gst  # noqa isort:skip
 
 from rgain3 import GainData, GainType, GSTError, util  # noqa isort:skip
 
@@ -43,7 +43,7 @@ class ReplayGain(GObject.GObject):
      - instantiate the class, passing it a list of file names and optionally the
        reference loudness level to use (defaults to 89 dB),
      - connect to the signals the class provides,
-     - get yourself a glib main loop (e.g. ``GObject.MainLoop`` or the one from
+     - get yourself a glib main loop (e.g. ``GLib.MainLoop`` or the one from
        GTK),
      - call ``replaygain_instance.start()`` to start processing,
      - start your main loop to dispatch events and
@@ -265,7 +265,7 @@ def calculate(*args, **kwargs):
             rg,
             ("all-finished", on_finished),
             ("error", on_error),):
-        loop = GObject.MainLoop()
+        loop = GLib.MainLoop()
         rg.start()
         loop.run()
     if exc_slot[0] is not None:

--- a/rgain3/script/replaygain.py
+++ b/rgain3/script/replaygain.py
@@ -19,7 +19,7 @@
 import os.path
 import sys
 
-from gi.repository import GObject
+from gi.repository import GLib
 
 from rgain3 import rgcalc, rgio, util
 from rgain3.script import Error, common_options, init_gstreamer
@@ -52,7 +52,7 @@ def calculate_gain(files, ref_level):
                               ("track-started", on_trk_started),
                               ("track-finished", on_trk_finished),
                               ("error", on_error),):
-        loop = GObject.MainLoop()
+        loop = GLib.MainLoop()
         rg.start()
         loop.run()
     if exc_slot[0] is not None:

--- a/test/test_rgcalc.py
+++ b/test/test_rgcalc.py
@@ -5,7 +5,7 @@ import gi
 
 gi.require_version("Gst", "1.0")
 
-from gi.repository import GObject, Gst  # noqa isort:skip
+from gi.repository import GLib, GObject, Gst  # noqa isort:skip
 
 from rgain3 import GainType, rgcalc, util  # noqa isort:skip
 
@@ -63,7 +63,7 @@ class TestReplayGain(unittest.TestCase):
         rg = rgcalc.ReplayGain(tracks)
 
         events = []
-        loop = GObject.MainLoop()
+        loop = GLib.MainLoop()
 
         def event(*args):
             """

--- a/test/test_rgio.py
+++ b/test/test_rgio.py
@@ -15,19 +15,19 @@ class TestGetTagsObject(unittest.TestCase):
         tags = self.reader_writer._get_tags_object(
             str(DATA_PATH / "missing-headers.mp3")
         )
-        self.assertEquals(tags.keys(), [])
+        self.assertEqual(tags.keys(), [])
         self.assertTrue(tags.filename.endswith("missing-headers.mp3"))
 
     def test_no_tags_mp3(self):
         tags = self.reader_writer._get_tags_object(
             str(DATA_PATH / "no-tags.mp3")
         )
-        self.assertEquals(tags.keys(), [])
+        self.assertEqual(tags.keys(), [])
         self.assertTrue(tags.filename.endswith("no-tags.mp3"))
 
     def test_album_mp3(self):
         tags = self.reader_writer._get_tags_object(
             str(DATA_PATH / "album-tag.mp3")
         )
-        self.assertEquals(tags.keys(), ["album"])
+        self.assertEqual(tags.keys(), ["album"])
         self.assertTrue(tags.filename.endswith("album-tag.mp3"))


### PR DESCRIPTION
* Use GLib.MainLoop instead of GObject.MainLoop
    
    GObject.MainLoop is a compatibility alias for code ported from historical
    versions of pygobject, but GMainLoop is actually part of GLib rather
    than GObject.

* Replace deprecated assertEquals with assertEqual