### PR TITLE
workflows: Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install system dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y gir1.2-gstreamer-1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly libcairo2-dev libgirepository1.0-dev
       - name: Install Python dependencies
         run: |

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ __version__ = Version("1.0.0")
 
 def requirements(filename: str) -> List[str]:
     with io.open(filename, "r") as fp:
-        return [l.strip() for l in fp if l.strip()]
+        return [line.strip() for line in fp if line.strip()]
 
 
 try:


### PR DESCRIPTION
* workflows: Update apt lists before installing packages

    A container will generally start with an outdated list of available
packages, which might not be available any more. This results in 404
errors when we try to download them. Update the list of packages before
installing them, so that we install the version that exists now.

* setup.py: Avoid flake8 warning for ambiguous variable name `l`