### PR TITLE
Add official support for Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,12 @@ jobs:
         - 3.6
         - 3.7
         - 3.8
+        - 3.9
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install system dependencies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 Changes
 =======
 
+- Added support for Python 3.9
 - Added support for MP4/iTunes album/artist tags
 - Updated the package structure so that the scripts are located in the `rgain`
   module. This means that they can now also be invoked using `python -m

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py35,py36,py37,py38,py39
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
Python 3.9 was released on Oct 5th, 2020

Release schedule: https://www.python.org/dev/peps/pep-0596/
What's new: https://docs.python.org/3.9/whatsnew/3.9.html

Closes #33 